### PR TITLE
Adding logic to allow plotting "all" for thresholds and levels

### DIFF
--- a/ush/metviewer/plot_vx_metviewer.py
+++ b/ush/metviewer/plot_vx_metviewer.py
@@ -325,7 +325,8 @@ def generate_metviewer_xml(cla, static_info, mv_database_info):
         argv:  Command-line arguments
 
     Returns:
-        None
+        string: Path to MetViewer batch plotting script
+        list:   List of strings indicating paths to XMLs for MetViewer batch plotting
     """
 
     static_info_config_fp = static_info['static_info_config_fp']
@@ -929,7 +930,6 @@ def plot_vx_metviewer(argv):
     mv_batch, output_xml_fp = generate_metviewer_xml(cla, static_info, mv_database_info)
 
     # Run MetViewer on the xml(s) to create verification plot(s).
-    # If output_xml_fp is a string, we only have one plot to make. If a list, we have multiple
 
     for output_xml in output_xml_fp:
         logging.info(dedent(f"""

--- a/ush/metviewer/plot_vx_metviewer.py
+++ b/ush/metviewer/plot_vx_metviewer.py
@@ -486,7 +486,7 @@ def generate_metviewer_xml(cla, static_info, mv_database_info):
                 #make a deep copy so we don't override original command-line arguments
                 clanew = copy.deepcopy(cla)
                 clanew.level_or_accum = level_or_accum
-                print(f"calling generate_metviewer_xml with {clanew.level_or_accum=}")
+                logging.debug(f"calling generate_metviewer_xml with {clanew.level_or_accum=}")
                 _,output_xml = generate_metviewer_xml(clanew, static_info, mv_database_info)
                 output_xmls.extend(output_xml)
             return(mv_machine_config_dict['mv_batch'],output_xmls)
@@ -580,7 +580,7 @@ def generate_metviewer_xml(cla, static_info, mv_database_info):
                 #make a deep copy so we don't override original command-line arguments
                 clanew = copy.deepcopy(cla)
                 clanew.threshold = threshold 
-                print(f"calling generate_metviewer_xml with {clanew.threshold=}")
+                logging.debug(f"calling generate_metviewer_xml with {clanew.threshold=}")
                 _,output_xml = generate_metviewer_xml(clanew, static_info, mv_database_info)
                 output_xmls.extend(output_xml)
             return(mv_machine_config_dict['mv_batch'],output_xmls)


### PR DESCRIPTION
Hi Gerard, sorry this is so late. Here is a description of the new logic:
 - Users can now specify "all" as an argument for either level or threshold (or both).
 - `generate_metviewer_xml` now returns a list of XML file paths rather than a single file path. If used in the original way, this simply means it's a single-item list, and the 
 - Returning a list of xmls allows the function to be called recursively, by "extending" the output list if there are already items in it
 - If "all" is specified for level or threshold, it loops over the dictionaries set in the `get_static_info` function: `valid_levels_by_fcst_var` and `valid_threshs_by_fcst_var` respectively. It then recursively calls the `generate_metviewer_xml` function for each of these levels and/or thresholds
 - Finally, at the top level we simply loop over each item in that list of xmls, calling `run_mv_batch` for each xml generated.

Let me know if you have any questions or there's anything else I can help with!